### PR TITLE
chore(demo/crossdomain):雑にcloudflare workerでdeploy

### DIFF
--- a/demo/crossdomain/.gitignore
+++ b/demo/crossdomain/.gitignore
@@ -1,0 +1,1 @@
+.denoflare

--- a/demo/crossdomain/README.md
+++ b/demo/crossdomain/README.md
@@ -1,0 +1,11 @@
+# cross-domain example
+
+with cloudflare worker
+
+https://twilight-credit-31a0.ababjam61.workers.dev/
+
+
+## refs
+
+- https://docs.deno.com/examples/cloudflare_workers_tutorial/
+ 

--- a/demo/crossdomain/main.ts
+++ b/demo/crossdomain/main.ts
@@ -1,0 +1,48 @@
+/**
+ * Welcome to Cloudflare Workers! This is your first worker.
+ *
+ * - Run "npm run dev" in your terminal to start a development server
+ * - Open a browser tab at http://localhost:8787/ to see your worker in action
+ * - Run "npm run deploy" to publish your worker
+ *
+ * Learn more at https://developers.cloudflare.com/workers/
+ */
+
+export default {
+  async fetch(request, env, ctx) {
+    // You can view your logs in the Observability dashboard
+    console.info({ message: "Hello World Worker received a request!" });
+    const html = `<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>GA4 Sandbox - Sub Domain</title>
+    <style>
+        body { font-family: sans-serif; text-align: center; padding-top: 50px; background-color: #eef; }
+    </style>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-YXBZRS2RDH"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-YXBZRS2RDH');
+    </script>
+</head>
+<body>
+    <h1>別ドメインページ</h1>
+    <p>クロスドメイン計測の遷移先ページです。</p>
+    <p>セッションが維持されていればテスト成功です。</p>
+    <p><a href="https://podhmo.github.io/ga4-sandbox/demo">[元のドメイン]トップページに戻る</a></p>
+</body>
+</html>
+`;
+    return new Response(html, {
+      headers: {
+        "Content-Type": "text/html",
+      },
+    });
+  },
+};

--- a/demo/index.html
+++ b/demo/index.html
@@ -47,7 +47,7 @@
 
     <section>
       <h2>クロスドメイン計測テスト</h2>
-      <p><a href="https://[あなたの別ドメイン]/sub-domain.html">6. 別ドメインへ遷移</a></p>
+      <p><a href="https://twilight-credit-31a0.ababjam61.workers.dev/">6. 別ドメインへ遷移</a></p>
     </section>
 
     <div class="long-content">


### PR DESCRIPTION
This pull request adds a new cross-domain example using a Cloudflare Worker, updates documentation, and adjusts the test link in the main demo. The main focus is to provide a working example for cross-domain measurement and tracking using Google Analytics 4 (GA4).

**New Cloudflare Worker cross-domain example:**

* Added `.gitignore` entry for `.denoflare` to ignore local development files.
* Added a new `README.md` with instructions and references for the cross-domain example in the `demo/crossdomain` directory.
* Implemented a new Cloudflare Worker in `main.ts` that serves an HTML page for cross-domain GA4 tracking, including Google Tag Manager integration and a link back to the main demo.

**Demo update:**

* Updated the cross-domain test link in `demo/index.html` to point to the deployed Cloudflare Worker example, replacing the placeholder domain.